### PR TITLE
documentation precheck: fails with major changes 

### DIFF
--- a/.github/workflows/documentation_precheck.yml
+++ b/.github/workflows/documentation_precheck.yml
@@ -57,8 +57,11 @@ jobs:
           pip install -r docsrc/requirements.txt
           pip install . 
       
+      # when building, removing local build and cached files is necessary
+      # otherwise the build will fail with major version updates
       - name: Build docs
         run : |
           cd docsrc/
+          make gitclean
           make github-action
           cd ..


### PR DESCRIPTION
The action fails with major version updates due to structural changes not reflected in locally stored sphinx autosummary folder files.

*Solution*:

clean local build and autosummary folder when executing the documentation precheck.