### PR TITLE
trusted publishers

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,9 +1,20 @@
 name: Upload Python Package
 
+## https://github.com/pypa/gh-action-pypi-publish/issues/166
+## pypi trusted publishing does not support reusable actions
+
 on:
   release:
     types: [published]
 
 jobs:
-  python-publish:
-    uses: giocaizzi/python-dev-actions/.github/workflows/python-publish.yml@main
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/${{ github.event.repository.name }}
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+      - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
pypi  trusted publishers does not support reusable actions